### PR TITLE
Increase options input width. API tokens were not fully displayed.

### DIFF
--- a/pagerduty/options.html
+++ b/pagerduty/options.html
@@ -5,6 +5,7 @@
         <style>
             body { color: #444; width: 500px; margin: 1em auto; zoom: 150%; }
             input, button { border: 1px solid #ccc; padding: 0.5em; display: block; }
+            input { width: 100%; }
             button { margin: 1em 0; }
             .heading { border-bottom: 1px solid #ccc; margin-bottom: 2em; padding: 0.5em; }
             .heading > img { float: left; margin-right: 0.5em; }


### PR DESCRIPTION
Increase the width of the input fields on the options page. Currently they are too small to fit the API token and most e-mail addresses.
- - -
## Before:
![image](https://cloud.githubusercontent.com/assets/192336/8550523/4bf9b034-248e-11e5-9d7d-77598f1dae2a.png)
- - -
## After:
![image](https://cloud.githubusercontent.com/assets/192336/8550553/78fc573a-248e-11e5-8995-505707a0370f.png)